### PR TITLE
Add basic logging

### DIFF
--- a/psrpcore/_payload.py
+++ b/psrpcore/_payload.py
@@ -147,14 +147,14 @@ class PSRPMessage:
     def fragment(
         self,
         length: int,
-    ) -> bytes:
+    ) -> Fragment:
         """Create a fragment with a maximum length."""
         data = self._data[:length]
         self._data = self._data[length:]
         fragment_id = self.fragment_counter
         end = len(self) == 0
 
-        return create_fragment(self.object_id, fragment_id, data, end)
+        return Fragment(self.object_id, fragment_id, fragment_id == 0, end, data)
 
 
 def create_message(

--- a/psrpcore/_server.py
+++ b/psrpcore/_server.py
@@ -112,7 +112,7 @@ class ServerRunspacePool(RunspacePool["ServerPipeline"]):
                 "accept Runspace Pool connections", self.state, [RunspacePoolState.Disconnected]
             )
 
-        # The incoming messages will be from a blank runspace pool so start back at 0
+        # The incoming messages will be from a blank runspace pool so start back at 1
         # TODO: Verify there are no incoming fragments/messages not processed.
         self._ci_count = 1
         self._fragment_count = 1

--- a/psrpcore/types/__init__.py
+++ b/psrpcore/types/__init__.py
@@ -8,6 +8,8 @@ Contains the public entrypoint for all the .NET/Pwsh type code that is used to
 exchange objects between Python and PowerShell.
 """
 
+import logging
+
 from psrpcore.types._base import (
     PSAliasProperty,
     PSCryptoProvider,
@@ -143,6 +145,8 @@ from psrpcore.types._psrp import (
     WarningRecordMsg,
 )
 from psrpcore.types._serializer import deserialize, serialize
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     "ApartmentState",


### PR DESCRIPTION
Adds basic logging. All these are debug logs that:

* Logs the fragment metadata on fragments created and received
* Logs the PSRP objects including the CLIXML data created and received
* Logs the state changes on pools and pipelines

I didn't create logs for each action as I think that might be overkill for now. By logging the raw data and state changes it should be possible to recreate the actions for debugging anyway.