### PR TITLE
Pin myst to older version for now

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-myst-parser
+myst-parser == 0.16.1
 Pygments
 Sphinx
 sphinx-rtd-theme


### PR DESCRIPTION
The latest myst-parser release breaks a lot of how the links are generated. I've got a partial fix in place for it but coming across the problem documented in https://github.com/executablebooks/MyST-Parser/issues/228#issuecomment-1041097220.

Until that is fixed this will just pin the docs to a version that is known to work.