### PR TITLE
Fix Multiple PowerShell Statements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 21.12b0
+  rev: 22.1.0
   hooks:
   - id: black
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,5 @@ python:
    version: 3.8
    install:
    - requirements: requirements-docs.txt
+   - method: pip
+     path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ deps =
 commands =
     python -m pytest -v --cov psrpcore --cov-report term-missing
 
-[testenv:lint]
+[testenv:sanity]
 commands =
     python -m black . --check
     python -m isort . --check-only


### PR DESCRIPTION
Fix multiple PowerShell statements to correct serialize the extra cmds
being invoked. This fixes the problem where the first cmd was not being
run by the PowerShell server.