### PR TITLE
Add better .NET object repr

### DIFF
--- a/src/psrpcore/_command.py
+++ b/src/psrpcore/_command.py
@@ -52,7 +52,6 @@ class Command(PSObject):
         self._merge_information = PipelineResultTypes.none
 
     def __repr__(self) -> str:
-        cls = self.__class__
         return (
             f"<{type(self).__name__} command_text={self.command_text!r} is_script={self.is_script} "
             f"use_local_scope={self.use_local_scope} end_of_statement={self.end_of_statement}>"

--- a/src/psrpcore/types/_base.py
+++ b/src/psrpcore/types/_base.py
@@ -729,6 +729,13 @@ class PSObject:
         else:
             return super().__str__()
 
+    def __repr__(self) -> str:
+        prop_entries = {p.name: p for p in self.PSObject.adapted_properties}
+        prop_entries.update({p.name: p for p in self.PSObject.extended_properties})
+
+        kw = ", ".join(f"{k}={v.get_value(self)!r}" for k, v in prop_entries.items())
+        return f"{type(self).__name__}({kw})"
+
 
 class PSType:
     """PSType class decorator.

--- a/src/psrpcore/types/_collection.py
+++ b/src/psrpcore/types/_collection.py
@@ -52,6 +52,12 @@ class PSDictBase(PSObject, dict):
     def __setitem__(self, key: typing.Any, value: typing.Any) -> None:
         dict.__setitem__(self, key, value)
 
+    def __repr__(self) -> str:
+        return dict.__repr__(self)
+
+    def __str__(self) -> str:
+        return dict.__str__(self)
+
 
 class _PSListBase(PSObject, list):
     """Common list base class for PSListBase and PSStackBase."""
@@ -79,6 +85,12 @@ class _PSListBase(PSObject, list):
             return super().__setitem__(key, value)
         else:
             return list.__setitem__(self, key, value)
+
+    def __repr__(self) -> str:
+        return list.__repr__(self)
+
+    def __str__(self) -> str:
+        return list.__str__(self)
 
 
 class PSListBase(_PSListBase):
@@ -135,6 +147,12 @@ class PSQueueBase(PSObject, queue.Queue):
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         pass  # We cannot call the base __init__() function in ase any properties are set.
+
+    def __repr__(self) -> str:
+        return queue.Queue.__repr__(self)
+
+    def __str__(self) -> str:
+        return queue.Queue.__str__(self)
 
 
 class PSStackBase(_PSListBase):

--- a/src/psrpcore/types/_enum.py
+++ b/src/psrpcore/types/_enum.py
@@ -89,6 +89,12 @@ class PSEnumBase(PSIntegerBase, enum.Enum, metaclass=PSEnumMeta):
     if you require a flag like enum, use :class:`PSFlagBase` as the base type.
     """
 
+    def __repr__(self) -> str:
+        return enum.Enum.__repr__(self)
+
+    def __str__(self) -> str:
+        return enum.Enum.__str__(self)
+
 
 @PSType(["System.Enum", "System.ValueType"], rehydrate=False)
 class PSFlagBase(PSIntegerBase, enum.Flag, metaclass=PSEnumMeta):
@@ -151,3 +157,9 @@ class PSFlagBase(PSIntegerBase, enum.Flag, metaclass=PSEnumMeta):
 
     def __invert__(self):  # type: ignore[no-untyped-def]
         return enum.IntFlag.__invert__(self)
+
+    def __repr__(self) -> str:
+        return enum.IntFlag.__repr__(self)
+
+    def __str__(self) -> str:
+        return enum.IntFlag.__str__(self)

--- a/src/psrpcore/types/_host.py
+++ b/src/psrpcore/types/_host.py
@@ -797,12 +797,6 @@ class HostInfo(PSObject):
         https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/510fd8f3-e3ac-45b4-b622-0ad5508a5ac6
     """
 
-    def __repr__(self) -> str:
-        return (
-            f"<HostInfo IsHostNull={self.IsHostNull} IsHostUINull={self.IsHostUINull} "
-            f"IsHostRawUINull={self.IsHostRawUINull} UseRunspaceHost={self.UseRunspaceHost}>"
-        )
-
     @classmethod
     def FromPSObjectForRemoting(
         cls,

--- a/src/psrpcore/types/_primitive.py
+++ b/src/psrpcore/types/_primitive.py
@@ -145,6 +145,13 @@ class PSIntegerBase(PSObject, int):
     ) -> None:
         super().__init__(*args, **kwargs)
 
+    def __repr__(self) -> str:
+        return int.__repr__(self)
+
+    def __str__(self) -> str:
+        # Use the PSObject.to_string in case this was a deserialized enum
+        return self.PSObject._to_string if self.PSObject._to_string is not None else int.__str__(self)
+
     def __abs__(self) -> "PSIntegerBase":
         return type(self)(super().__abs__())
 
@@ -200,6 +207,12 @@ class PSStringBase(PSObject, str):
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__()
 
+    def __repr__(self) -> str:
+        return str.__repr__(self)
+
+    def __str__(self) -> str:
+        return str.__str__(self)
+
     def __getitem__(self, item: typing.Union[int, str, slice]) -> "PSStringBase":
         # Allows slicing alongside getting extended properties which preserves the underlying type.
         if isinstance(item, str):
@@ -230,8 +243,6 @@ class PSString(PSStringBase):
     .. _System.String:
         https://docs.microsoft.com/en-us/dotnet/api/system.string?view=net-5.0
     """
-
-    pass
 
 
 @PSType(["System.Char", "System.ValueType"], tag="C")
@@ -291,6 +302,9 @@ class PSChar(PSObject, int):
     def __str__(self) -> str:
         # While backed by an int value, the str representation should be the char it represents.
         return str(chr(self))
+
+    def __repr__(self) -> str:
+        return int.__repr__(self)
 
 
 PSBool = bool
@@ -375,7 +389,7 @@ class PSDateTime(PSObject, datetime.datetime):
         return instance
 
     def __repr__(self) -> str:
-        datetime_repr = super().__repr__()[:-1]
+        datetime_repr = datetime.datetime.__repr__(self)[:-1]
         return f"{datetime_repr}, nanosecond={self.nanosecond})"
 
     def __str__(self) -> str:
@@ -499,8 +513,7 @@ class PSDuration(PSObject, datetime.timedelta):
             values.append("0")
 
         kwargs = ", ".join(values)
-        cls = self.__class__
-        return f"{cls.__qualname__}({kwargs})"
+        return f"{type(self).__name__}({kwargs})"
 
     def __str__(self) -> str:
         s = ""
@@ -855,6 +868,12 @@ class PSSingle(PSObject, float):
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__()
 
+    def __repr__(self) -> str:
+        return float.__repr__(self)
+
+    def __str__(self) -> str:
+        return float.__str__(self)
+
 
 @PSType(["System.Double", "System.ValueType"], tag="Db")
 class PSDouble(PSObject, float):
@@ -880,6 +899,12 @@ class PSDouble(PSObject, float):
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__()
 
+    def __repr__(self) -> str:
+        return float.__repr__(self)
+
+    def __str__(self) -> str:
+        return float.__str__(self)
+
 
 @PSType(["System.Decimal", "System.ValueType"], tag="D")
 class PSDecimal(PSObject, decimal.Decimal):
@@ -904,6 +929,12 @@ class PSDecimal(PSObject, decimal.Decimal):
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__()
+
+    def __repr__(self) -> str:
+        return decimal.Decimal.__repr__(self)
+
+    def __str__(self) -> str:
+        return decimal.Decimal.__str__(self)
 
 
 @PSType(["System.Byte[]", "System.Array"], tag="BA")
@@ -938,6 +969,12 @@ class PSByteArray(PSObject, bytes):
         else:
             # String indexing, need to preserve the type.
             return type(self)(bytes.__getitem__(self, item))
+
+    def __repr__(self) -> str:
+        return bytes.__repr__(self)
+
+    def __str__(self) -> str:
+        return bytes.__str__(self)
 
 
 @PSType(["System.Guid", "System.ValueType"], tag="G")
@@ -989,6 +1026,12 @@ class PSGuid(PSObject, uuid.UUID):
             return
 
         super().__setattr__(name, value)
+
+    def __repr__(self) -> str:
+        return uuid.UUID.__repr__(self)
+
+    def __str__(self) -> str:
+        return uuid.UUID.__str__(self)
 
 
 @PSType(["System.Uri"], tag="URI")
@@ -1128,8 +1171,7 @@ class PSVersion(PSObject):
                 values.append(f"{field}={value}")
 
         kwargs = ", ".join(values)
-        cls = self.__class__
-        return f"{cls.__module__}.{cls.__qualname__}({kwargs})"
+        return f"{type(self).__name__}({kwargs})"
 
     def __str__(self) -> str:
         parts = [self.major, self.minor, self.build, self.revision]
@@ -1315,6 +1357,9 @@ class PSSecureString(PSObject):
         dec_str = PSString(raw)
         dec_str.PSObject = self.PSObject
         return dec_str
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}()"
 
     def __str__(self) -> str:
         return (str(self._value) if self._encrypted else self.PSObject.type_names[0]) or ""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -88,8 +88,8 @@ def test_open_runspacepool():
         repr(init_runspace_pool) == f"<InitRunspacePoolEvent runspace_pool_id={client.runspace_pool_id!r} "
         f"min_runspaces=1 max_runspaces=1 ps_thread_options=<PSThreadOptions.Default: 0> "
         f"apartment_state=<ApartmentState.Unknown: 2> "
-        f"host_info=<HostInfo IsHostNull=True IsHostUINull=True IsHostRawUINull=True UseRunspaceHost=True> "
-        "application_arguments={}>"
+        f"host_info=HostInfo(IsHostNull=True, IsHostUINull=True, IsHostRawUINull=True, UseRunspaceHost=True, "
+        f"HostDefaultData=None) application_arguments={{}}>"
     )
     assert init_runspace_pool.apartment_state == ApartmentState.Unknown
     assert init_runspace_pool.application_arguments == {}
@@ -123,8 +123,8 @@ def test_open_runspacepool():
     }
     assert (
         repr(private_data) == f"<ApplicationPrivateDataEvent runspace_pool_id={client.runspace_pool_id!r}: "
-        f"{{'PSVersionTable': {{'PSRemotingProtocolVersion': psrpcore.types._primitive.PSVersion(major=2, minor=3), "
-        f"'SerializationVersion': psrpcore.types._primitive.PSVersion(major=1, minor=1, build=0, revision=1)}}}}>"
+        f"{{'PSVersionTable': {{'PSRemotingProtocolVersion': PSVersion(major=2, minor=3), 'SerializationVersion': "
+        f"PSVersion(major=1, minor=1, build=0, revision=1)}}}}>"
     )
     assert client.state == RunspacePoolState.Opening
     assert server.state == RunspacePoolState.Opened
@@ -792,8 +792,8 @@ def test_create_pipeline():
         f"<CreatePipelineEvent runspace_pool_id={client.runspace_pool_id!r} pipeline_id={c_pipeline.pipeline_id!r} "
         f"pipeline=<PowerShell add_to_history=False apartment_state=<ApartmentState.Unknown: 2> "
         f"commands=[<Command command_text='testing' is_script=True use_local_scope=None end_of_statement=True>] "
-        f"history=None host=<HostInfo IsHostNull=True IsHostUINull=True IsHostRawUINull=True UseRunspaceHost=True> "
-        f"is_nested=False no_input=True remote_stream_options=<RemoteStreamOptions.none: 0> "
+        f"history=None host=HostInfo(IsHostNull=True, IsHostUINull=True, IsHostRawUINull=True, UseRunspaceHost=True, "
+        f"HostDefaultData=None) is_nested=False no_input=True remote_stream_options=<RemoteStreamOptions.none: 0> "
         f"redirect_shell_error_to_out=True>>"
     )
     assert isinstance(s_pipeline.metadata, psrpcore.PowerShell)

--- a/tests/types/test_collection.py
+++ b/tests/types/test_collection.py
@@ -71,6 +71,8 @@ def test_ps_stack():
     actual = deserialize(element)
     assert isinstance(actual, collection.PSStack)
     assert isinstance(actual, list)
+    assert str(actual) == "['abc', 123, 1, True]"
+    assert repr(actual) == "['abc', 123, 1, True]"
     assert actual == ["abc", 123, PSInt64(1), True]
     # Verify we can still index the list
     assert actual[0] == "abc"
@@ -111,6 +113,8 @@ def test_ps_stack_with_properties():
     actual = deserialize(element)
     assert isinstance(actual, collection.PSStack)
     assert isinstance(actual, list)
+    assert str(actual) == "[0, 1, 97, 2]"
+    assert repr(actual) == "[0, 1, 97, 2]"
     assert actual == [0, 1, PSChar("a"), 2]
     # Verify we can still index the list
     assert actual[0] == 0
@@ -150,6 +154,8 @@ def test_ps_queue():
     actual = deserialize(element)
     assert isinstance(actual, collection.PSQueue)
     assert isinstance(actual, queue.Queue)
+    assert str(actual) == queue.Queue.__str__(actual)
+    assert repr(actual) == queue.Queue.__repr__(actual)
 
     assert actual.get() == "abc"
     assert actual.get() == 123
@@ -214,6 +220,8 @@ def test_ps_queue_with_properties():
     actual = deserialize(element)
     assert isinstance(actual, collection.PSQueue)
     assert isinstance(actual, queue.Queue)
+    assert str(actual) == queue.Queue.__str__(actual)
+    assert repr(actual) == queue.Queue.__repr__(actual)
 
     assert actual.get() == "abc"
     assert actual.get() == 123
@@ -256,6 +264,9 @@ def test_ps_list():
     actual = deserialize(element)
     assert isinstance(actual, collection.PSList)
     assert isinstance(actual, list)
+    assert str(actual) == "['abc', 123, 1, True]"
+    assert repr(actual) == "['abc', 123, 1, True]"
+
     assert actual == ["abc", 123, PSInt64(1), True]
     # Verify we can still index the list
     assert actual[0] == "abc"
@@ -423,6 +434,8 @@ def test_ps_dict_with_properties():
     actual = deserialize(element)
     assert isinstance(actual, collection.PSDict)
     assert isinstance(actual, dict)
+    assert str(actual) == f"{{'key': 'dict', {COMPLEX_STRING!r}: 'dict'}}"
+    assert repr(actual) == f"{{'key': 'dict', {COMPLEX_STRING!r}: 'dict'}}"
 
     # In the case of a prop shadowing a dict, [] will favour the dict, and . will only get props
     assert actual["key"] == "dict"
@@ -465,5 +478,8 @@ def test_ps_ienumerable():
     actual = deserialize(element)
     assert isinstance(actual, collection.PSIEnumerable)
     assert isinstance(actual, list)
+    assert str(actual) == "[0, 1, 2, 3, 4]"
+    assert repr(actual) == "[0, 1, 2, 3, 4]"
+
     assert actual == [0, 1, 2, 3, 4]
     assert actual.PSTypeNames == ["System.Collections.IEnumerable", "System.Object"]

--- a/tests/types/test_complex.py
+++ b/tests/types/test_complex.py
@@ -35,6 +35,7 @@ def test_ps_custom_object_empty():
     assert isinstance(actual, complex.PSCustomObject)
     assert actual.PSTypeNames == ["System.Management.Automation.PSCustomObject", "System.Object"]
     assert str(actual) == "to string value"
+    assert repr(actual) == "PSCustomObject()"
 
 
 def test_ps_custom_object_type_name():
@@ -64,6 +65,28 @@ def test_ps_custom_object_type_name():
         "Deserialized.System.Object",
     ]
     assert str(actual) == "to string value"
+    assert repr(actual) == "PSObject(My Property='Value')"
+
+
+def test_ps_custom_object_properties():
+    obj = complex.PSCustomObject(Foo="Bar", Hello="World")
+    assert obj.PSTypeNames == ["System.Management.Automation.PSCustomObject", "System.Object"]
+
+    element = serialize(obj)
+
+    actual = ElementTree.tostring(element, encoding="utf-8").decode()
+    assert (
+        actual == '<Obj RefId="0">'
+        '<TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN>'
+        '<MS><S N="Foo">Bar</S><S N="Hello">World</S></MS>'
+        "</Obj>"
+    )
+
+    actual = deserialize(element)
+    assert isinstance(actual, complex.PSCustomObject)
+    assert actual.PSTypeNames == ["System.Management.Automation.PSCustomObject", "System.Object"]
+    assert str(actual) == "PSCustomObject(Foo='Bar', Hello='World')"
+    assert repr(actual) == "PSCustomObject(Foo='Bar', Hello='World')"
 
 
 def test_psrp_pipeline_result_types():

--- a/tests/types/test_primitive.py
+++ b/tests/types/test_primitive.py
@@ -1033,6 +1033,8 @@ def test_ps_decimal(input_value, expected):
     ps_value = primitive.PSDecimal(input_value)
     assert isinstance(ps_value, primitive.PSDecimal)
     assert isinstance(ps_value, decimal.Decimal)
+    assert str(ps_value) == decimal.Decimal.__str__(ps_value)
+    assert repr(ps_value) == decimal.Decimal.__repr__(ps_value)
 
     element = serialize(ps_value)
     actual = ElementTree.tostring(element, encoding="utf-8", method="xml").decode()
@@ -1074,6 +1076,8 @@ def test_ps_byte_array(input_value, expected):
     ps_value = primitive.PSByteArray(input_value)
     assert isinstance(ps_value, primitive.PSByteArray)
     assert isinstance(ps_value, bytes)
+    assert str(ps_value) == bytes.__str__(ps_value)
+    assert repr(ps_value) == bytes.__repr__(ps_value)
 
     element = serialize(ps_value)
     actual = ElementTree.tostring(element, encoding="utf-8", method="xml").decode()
@@ -1130,6 +1134,8 @@ def test_ps_guid(input_value, expected):
     ps_value = primitive.PSGuid(input_value)
     assert isinstance(ps_value, primitive.PSGuid)
     assert isinstance(ps_value, uuid.UUID)
+    assert str(ps_value) == uuid.UUID.__str__(ps_value)
+    assert repr(ps_value) == uuid.UUID.__repr__(ps_value)
 
     element = serialize(ps_value)
     actual = ElementTree.tostring(element, encoding="utf-8", method="xml").decode()
@@ -1285,7 +1291,7 @@ def test_ps_version_with_properties():
 def test_ps_version_str(input_value, expected_repr):
     actual = primitive.PSVersion(input_value)
     assert str(actual) == input_value
-    assert repr(actual) == f"psrpcore.types._primitive.PSVersion({expected_repr})"
+    assert repr(actual) == f"PSVersion({expected_repr})"
 
 
 @pytest.mark.parametrize(
@@ -1395,6 +1401,7 @@ def test_ps_version_compare_invalid():
 def test_ps_secure_string():
     ps_value = primitive.PSSecureString(COMPLEX_STRING)
     assert str(ps_value) == "System.Security.SecureString"
+    assert repr(ps_value) == "PSSecureString()"
     assert ps_value.decrypt() == COMPLEX_STRING
 
     element = serialize(ps_value)


### PR DESCRIPTION
Add a default __repr__ for a PSObject to provide an easier user
experience when looking at PSObjects returned by the server.