### PR TITLE
Do not use ref for lists and dicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2.0 - TBD
 
++ Do not use references for lists and dict types when serializing
+
 ## 0.1.0 - 2022-03-28
 
 Initial release

--- a/src/psrpcore/types/_serializer.py
+++ b/src/psrpcore/types/_serializer.py
@@ -1006,7 +1006,7 @@ class _Serializer:
             ref_id = self._obj_ref.setdefault(value, next_ref_id)
         except TypeError as e:
             # Some objects cannot have a weakref, try id() only when dealing with known workable types.
-            if isinstance(value, (dict, enum.Enum, list)):
+            if isinstance(value, enum.Enum):
                 ref_id = self._obj_ref_enum.setdefault(id(value), next_ref_id)
 
             else:

--- a/tests/types/test_complex.py
+++ b/tests/types/test_complex.py
@@ -561,9 +561,11 @@ def test_error_record_with_invocation_info():
         "</TN>"
         "<MS>"
         '<Obj RefId="1" N="Exception">'
-        '<TN RefId="1"><T>System.Exception</T>'
+        '<TN RefId="1">'
+        "<T>System.Exception</T>"
         "<T>System.Object</T>"
-        "</TN><Props>"
+        "</TN>"
+        "<Props>"
         '<S N="Message">Exception</S>'
         '<Nil N="Data" />'
         '<Nil N="HelpLink" />'
@@ -626,22 +628,28 @@ def test_error_record_with_invocation_info():
         "</Obj>"
         "</Props>"
         "</Obj>"
-        '<I32 N="ErrorCategory_Category">0</I32'
-        '><Nil N="ErrorCategory_Activity" />'
+        '<I32 N="ErrorCategory_Category">0</I32>'
+        '<Nil N="ErrorCategory_Activity" />'
         '<Nil N="ErrorCategory_Reason" />'
         '<Nil N="ErrorCategory_TargetName" />'
         '<Nil N="ErrorCategory_TargetType" />'
         '<S N="ErrorCategory_Message">NotSpecified (:) [], </S>'
         '<B N="SerializeExtendedInfo">true</B>'
-        '<Ref RefId="3" N="InvocationInfo_BoundParameters" />'
+        '<Obj RefId="6" N="InvocationInfo_BoundParameters">'
+        '<TNRef RefId="3" />'
+        "<DCT>"
+        '<En><S N="Key">Path</S><S N="Value">C:\\temp\\file.txt</S></En>'
+        "</DCT>"
+        "</Obj>"
         '<Ref RefId="4" N="InvocationInfo_CommandOrigin" />'
         '<B N="InvocationInfo_ExpectingInput">false</B>'
         '<S N="InvocationInfo_InvocationName">Remove-Item</S>'
         '<S N="InvocationInfo_Line">10</S>'
         '<I32 N="InvocationInfo_OffsetInLine">20</I32>'
         '<I64 N="InvocationInfo_HistoryId">10</I64>'
-        '<Obj RefId="6" N="InvocationInfo_PipelineIterationInfo">'
-        '<TNRef RefId="5" /><LST />'
+        '<Obj RefId="7" N="InvocationInfo_PipelineIterationInfo">'
+        '<TNRef RefId="5" />'
+        "<LST />"
         "</Obj>"
         '<I32 N="InvocationInfo_PipelineLength">30</I32>'
         '<I32 N="InvocationInfo_PipelinePosition">40</I32>'
@@ -650,9 +658,11 @@ def test_error_record_with_invocation_info():
         '<S N="InvocationInfo_PositionMessage">position message</S>'
         '<Nil N="InvocationInfo_ScriptLineNumber" />'
         '<Nil N="InvocationInfo_ScriptName" />'
-        '<Ref RefId="5" N="InvocationInfo_UnboundArguments" />'
-        '<B N="SerializeExtent">false</B>'
-        '<Obj RefId="7" N="PipelineIterationInfo">'
+        '<Obj RefId="8" N="InvocationInfo_UnboundArguments">'
+        '<TNRef RefId="5" />'
+        "<LST><B>true</B></LST>"
+        '</Obj><B N="SerializeExtent">false</B>'
+        '<Obj RefId="9" N="PipelineIterationInfo">'
         '<TNRef RefId="5" />'
         "<LST><I32>1</I32></LST>"
         "</Obj>"


### PR DESCRIPTION
Avoid using a ref during a list/dict serialization. There is no
guarantee that the id() for these types will be unique during the
serialization process as certain property types and classes could
generate a short lived object causing conflicts in the id() value. The
values of the list can still be created as a reference placeholder if
they contain a complex type that is referencable.