### PR TITLE
Fix serialization of broken surrogates in strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 0.2.0 - TBD
+## 0.1.2 - TBD
+
++ Fix serialization of strings that include half surrogate pair `[char]` values
 
 ## 0.1.1 - 2022-04-06
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = psrpcore
-version = 0.2.0
+version = 0.1.2
 url = https://github.com/jborean93/psrpcore
 project_urls =
     Documentation = https://psrpcore.readthedocs.io/

--- a/src/psrpcore/types/_primitive.py
+++ b/src/psrpcore/types/_primitive.py
@@ -1349,7 +1349,7 @@ class PSSecureString(PSObject):
         if self._cipher:
             b_enc = base64.b64decode(self._value)
             b_dec = self._cipher.decrypt(b_enc)
-            raw = b_dec.decode("utf-16-le")
+            raw = b_dec.decode("utf-16-le", errors="surrogatepass")
 
         else:
             raw = self._value
@@ -1374,7 +1374,7 @@ class PSSecureString(PSObject):
         if not instance._encrypted:
             # The value was provided by the user without a cipher. Use the one passed in by the serializer to encrypt
             # the value and return that for serialization.
-            b_value = instance._value.encode("utf-16-le")
+            b_value = instance._value.encode("utf-16-le", errors="surrogatepass")
             b_enc = cipher.encrypt(b_value)
             enc_value = base64.b64encode(b_enc).decode()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,8 @@ import psrpcore
 BUFFER_SIZE = 327681
 
 # Contains control characters, non-ascii chars, and chars that are surrogate pairs in UTF-16
-COMPLEX_STRING = "treble clef\n _x0000_ _X0000_ %s café" % b"\xF0\x9D\x84\x9E".decode("utf-8")
-COMPLEX_ENCODED_STRING = "treble clef_x000A_ _x005F_x0000_ _x005F_X0000_ _xD834__xDD1E_ café"
+COMPLEX_STRING = "treble clef\n _x0000_ _X0000_ %s café \uD83C" % b"\xF0\x9D\x84\x9E".decode("utf-8")
+COMPLEX_ENCODED_STRING = "treble clef_x000A_ _x005F_x0000_ _x005F_X0000_ _xD834__xDD1E_ café _xD83C_"
 
 T = typing.TypeVar("T", psrpcore.ClientRunspacePool, psrpcore.ServerRunspacePool)
 

--- a/tests/test_integration_client.py
+++ b/tests/test_integration_client.py
@@ -74,7 +74,8 @@ def test_runspace_with_pipeline_output(client_pwsh: ClientTransport):
 $DebugPreference = 'Continue'
 $WarningPreference = 'Continue'
 
-$complexString = "treble clef\n _x0000_ _X0000_ $([Char]::ConvertFromUtf32(0x0001D11E)) café"
+$musicalNote = [Char]::ConvertFromUtf32(0x0001F3B5)
+$complexString = "treble clef\n _x0000_ _X0000_ $([Char]::ConvertFromUtf32(0x0001D11E)) café $($musicalNote[0])"
 
 # Test out the streams
 "output"
@@ -108,7 +109,7 @@ $null
 [Version]"1.2.3.4"
 [xml]"<obj>test</obj>"
 { echo "scriptblock" }
-ConvertTo-SecureString -AsPlainText -Force -String "test"
+ConvertTo-SecureString -AsPlainText -Force -String $complexString
 [IO.FileMode]::Open
 
 $obj = [PSCustomObject]@{
@@ -333,7 +334,7 @@ public class PSRPCore
     client_pwsh.data()
     enc_key = client_pwsh.next_event()
     assert isinstance(enc_key, psrpcore.EncryptedSessionKeyEvent)
-    assert events[28].data.decrypt() == "test"
+    assert events[28].data.decrypt() == COMPLEX_STRING
 
     with pytest.raises(psrpcore.PSRPCoreError, match="Must close existing pipelines before closing the pool"):
         runspace.close()

--- a/tests/types/test_primitive.py
+++ b/tests/types/test_primitive.py
@@ -1408,14 +1408,14 @@ def test_ps_secure_string():
     actual = ElementTree.tostring(element, encoding="utf-8", method="xml").decode()
     assert (
         actual
-        == "<SS>dAByAGUAYgBsAGUAIABjAGwAZQBmAAoAIABfAHgAMAAwADAAMABfACAAXwBYADAAMAAwADAAXwAgADTYHt0gAGMAYQBmAOkA</SS>"
+        == "<SS>dAByAGUAYgBsAGUAIABjAGwAZQBmAAoAIABfAHgAMAAwADAAMABfACAAXwBYADAAMAAwADAAXwAgADTYHt0gAGMAYQBmAOkAIAA82A==</SS>"
     )
 
     actual = deserialize(element)
     assert isinstance(actual, primitive.PSSecureString)
     assert not isinstance(actual, str)
     assert str(actual) == (
-        "dAByAGUAYgBsAGUAIABjAGwAZQBmAAoAIABfAHgAMAAwADAAMABfACAAXwBYADAAMAAwADAAXwAgADTYHt0gAGMAYQBmAOkA"
+        "dAByAGUAYgBsAGUAIABjAGwAZQBmAAoAIABfAHgAMAAwADAAMABfACAAXwBYADAAMAAwADAAXwAgADTYHt0gAGMAYQBmAOkAIAA82A=="
     )
     assert actual.PSTypeNames == ["System.Security.SecureString", "System.Object"]
 


### PR DESCRIPTION
Fix the serialization of strings that contain broken surrogate pair
chars. This is required as .NET strings are essentially an array of char
objects. Surrogate pairs are composed of 2 chars which means a string
can contain half a surrogate pair.

This also fixes up the serialization of other string like types to
handle such scenarios like this.