### PR TITLE
Add CLIXML string conversion functions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,7 @@
     "python.testing.pytestEnabled": true,
     "[python]": {
         "editor.codeActionsOnSave": {
-            "source.organizeImports": true
+            "source.organizeImports": "explicit"
         },
     },
     "python.linting.ignorePatterns": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## 0.2.3 - TBD
+## 0.3.0 - TBD
 
 * Tested with Python 3.12
+* Added `psrpcore.types.deserialize_clixml` and `psrpcore.types.serialize_clixml`
+  * These methods can deserialize and serialize CLIXML strings directly
+* Removed invalid `__init__.py` entries `ps_data_packet` and `ps_guid_packet` as they were never defined
 
 ## 0.2.2 - 2023-03-01
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "psrpcore"
-version = "0.2.3"
+version = "0.3.0"
 description = "Core components for the PowerShell Remoting Protocol"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/psrpcore/__init__.py
+++ b/src/psrpcore/__init__.py
@@ -15,6 +15,7 @@ from psrpcore._client import (
     ClientRunspacePool,
 )
 from psrpcore._command import Command
+from psrpcore._crypto import PSRemotingCrypto
 from psrpcore._events import (
     ApplicationPrivateDataEvent,
     ConnectRunspacePoolEvent,
@@ -95,10 +96,9 @@ __all__ = [
     "PipelineStateEvent",
     "PowerShell",
     "ProgressRecordEvent",
-    "ps_data_packet",
-    "ps_guid_packet",
     "PublicKeyEvent",
     "PublicKeyRequestEvent",
+    "PSRemotingCrypto",
     "ResetRunspaceStateEvent",
     "RunspacePoolHostCallEvent",
     "RunspacePoolHostResponseEvent",

--- a/src/psrpcore/types/__init__.py
+++ b/src/psrpcore/types/__init__.py
@@ -144,7 +144,12 @@ from psrpcore.types._psrp import (
     VerboseRecordMsg,
     WarningRecordMsg,
 )
-from psrpcore.types._serializer import deserialize, serialize
+from psrpcore.types._serializer import (
+    deserialize,
+    deserialize_clixml,
+    serialize,
+    serialize_clixml,
+)
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
@@ -272,6 +277,8 @@ __all__ = [
     "add_note_property",
     "add_script_property",
     "deserialize",
+    "deserialize_clixml",
     "ps_isinstance",
     "serialize",
+    "serialize_clixml",
 ]

--- a/tests/test_clixml_proc.py
+++ b/tests/test_clixml_proc.py
@@ -1,0 +1,94 @@
+# Copyright: (c) 2024, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+import base64
+import subprocess
+
+import psrpcore
+
+from .conftest import PWSH_PATH, ClientTransport, FakeCryptoProvider, run_pipeline
+
+
+def test_deserialize_process_clixml() -> None:
+    cmd = r"""
+"string" | Add-Member -NotePropertyName MyProp -NotePropertyValue foo -PassThru
+1
+[PSCustomObject]@{
+    PSTypeName = 'MyType'
+    Prop1 = $true
+    Prop2 = [Int64]2
+}
+"""
+
+    enc_cmd = base64.b64encode(cmd.encode("utf-16-le")).decode()
+    res = subprocess.run(
+        [PWSH_PATH or "pwsh", "-OutputFormat", "xml", "-EncodedCommand", enc_cmd],
+        capture_output=True,
+        text=True,
+    )
+
+    actual = psrpcore.types.deserialize_clixml(res.stdout, FakeCryptoProvider())
+    assert isinstance(actual, list)
+    assert len(actual) == 3
+    assert actual[0] == "string"
+    assert isinstance(actual[0], psrpcore.types.PSString)
+    assert actual[0].MyProp == "foo"
+    assert actual[1] == 1
+    assert isinstance(actual[1], psrpcore.types.PSInt)
+    assert isinstance(actual[2], psrpcore.types.PSObject)
+    assert actual[2].PSTypeNames == [
+        "Deserialized.MyType",
+        "Deserialized.System.Management.Automation.PSCustomObject",
+        "Deserialized.System.Object",
+    ]
+    assert actual[2].Prop1 is True
+    assert actual[2].Prop2 == 2
+    assert isinstance(actual[2].Prop2, psrpcore.types.PSInt64)
+
+
+def test_serialize_process_clixml(client_pwsh: ClientTransport) -> None:
+    obj1 = psrpcore.types.PSString("string")
+    obj1.PSObject.extended_properties.append(psrpcore.types.PSNoteProperty("MyProp", "foo"))
+    obj2 = psrpcore.types.PSCustomObject(
+        PSTypeName="MyType",
+        Prop1=True,
+        Prop2=psrpcore.types.PSInt64(2),
+    )
+    clixml = psrpcore.types.serialize_clixml([obj1, 1, obj2], FakeCryptoProvider())
+
+    client_pwsh.runspace.open()
+    client_pwsh.data()
+    while client_pwsh.runspace.state == psrpcore.types.RunspacePoolState.Opening:
+        client_pwsh.next_event()
+
+    cmd = rf"""
+$data = @'
+{clixml}
+'@
+
+[System.Management.Automation.PSSerializer]::Deserialize($data)
+"""
+    res = run_pipeline(client_pwsh, cmd)
+    assert len(res) == 4
+    assert isinstance(res[0], psrpcore.PipelineOutputEvent)
+    assert isinstance(res[0].data, psrpcore.types.PSString)
+    assert res[0].data == "string"
+    assert res[0].data.MyProp == "foo"
+
+    assert isinstance(res[1], psrpcore.PipelineOutputEvent)
+    assert isinstance(res[1].data, psrpcore.types.PSInt)
+    assert res[1].data == 1
+
+    assert isinstance(res[2], psrpcore.PipelineOutputEvent)
+    assert isinstance(res[2].data, psrpcore.types.PSObject)
+    assert res[2].data.PSTypeNames == [
+        "Deserialized.Deserialized.MyType",
+        "Deserialized.Deserialized.System.Management.Automation.PSCustomObject",
+        "Deserialized.Deserialized.System.Object",
+    ]
+    assert res[2].data.Prop1 is True
+    assert res[2].data.Prop2 == 2
+    assert isinstance(res[2].data.Prop2, psrpcore.types.PSInt64)
+
+    assert isinstance(res[3], psrpcore.PipelineStateEvent)
+    assert res[3].state == psrpcore.types.PSInvocationState.Completed


### PR DESCRIPTION
Add functions to easily convert CLIXML strings emitted by PowerShell directly. This includes strings from -OutputFormat Xml, Export-Clixml, and the PSSerializer class.